### PR TITLE
Add a config node to hold the API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .DS_store
 *.backup
 *.tgz
+.idea/

--- a/natRail-config.html
+++ b/natRail-config.html
@@ -1,0 +1,25 @@
+<script type="text/javascript">
+    RED.nodes.registerType('natRail-config',{
+        category: 'config',
+        defaults: {
+            name: {value:""}
+        },
+        credentials: {
+            apiKey: {type:"text", required: true}
+        },
+        label: function() {
+            return this.name || "National Rail API Key";
+        }
+    });
+</script>
+
+<script type="text/html" data-template-name="natRail-config">
+    <div class="form-row">
+        <label for="node-config-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-config-input-name" data-i18n="[placeholder]node-red:common.label.name">
+    </div>
+    <div class="form-row">
+        <label for="node-config-input-apiKey"><i class="fa fa-key"></i> API Key</label>
+        <input type="text" id="node-config-input-apiKey">
+    </div>
+</script>

--- a/natRail-config.js
+++ b/natRail-config.js
@@ -1,0 +1,10 @@
+module.exports = function(RED) {
+    function NationalRailConfigNode(config) {
+        RED.nodes.createNode(this, config);
+        this.name = config.name;
+    }
+
+    RED.nodes.registerType("natRail-config", NationalRailConfigNode, {
+        credentials: { apiKey: {type:"text"} }
+    });
+}

--- a/natRail.html
+++ b/natRail.html
@@ -13,12 +13,12 @@
         <input type="text" id="node-input-destscode" data-i18n="[placeholder]common.label.destscode">
     </div>
     <div class="form-row">
-        <label for="node-input-apikey"><i class="fa fa-key"></i> API Key</label>
-        <input type="text" id="node-input-apikey">
+        <label for="node-input-api"><i class="fa fa-key"></i> API Key</label>
+        <input type="text" id="node-input-api">
     </div>
     <div class="form-row">
-        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="common.label.name"></span></label>
-        <input type="text" id="node-input-name" data-i18n="[placeholder]common.label.name">
+        <label for="node-input-name"><i class="fa fa-tag"></i> <span data-i18n="node-red:common.label.name"></span></label>
+        <input type="text" id="node-input-name" data-i18n="[placeholder]node-red:common.label.name">
     </div>
     <div class="form-tips">For a list of valid Station Codes see
     <a href="http://www.nationalrail.co.uk/static/documents/content/station_codes.csv">this link</a>.</div>
@@ -53,10 +53,8 @@
             name: {value:""},
             scode: {value:"WIN",required:true},
             destscode: {value:"",required:false},
-            property: {value:"payload",required:true}
-        },
-        credentials: {
-            apikey: {type:"text"}
+            property: {value:"payload",required:true},
+            api: {value:"", type: "natRail-config", required:true}
         },
         inputs:1,
         outputs:1,

--- a/natRail.js
+++ b/natRail.js
@@ -8,9 +8,15 @@ module.exports = function(RED) {
         this.property = n.property||"payload";
         this.scode = n.scode || "WIN";
         this.destscode = n.destscode || "";
-        var credentials = this.credentials;
-        if ((credentials) && (credentials.hasOwnProperty("apikey"))) { this.apikey = credentials.apikey; }
-        else { this.error("No API key set"); }
+
+        // grab API key from configuration node
+        this.api = RED.nodes.getNode(n.api);
+        if (this.api) {
+            this.apikey = this.api.credentials.apiKey;
+        } else {
+            this.error("No API key set");
+        }
+
         var rail = new Rail(this.apikey);
         var node = this;
 
@@ -48,7 +54,5 @@ module.exports = function(RED) {
             else { node.send(msg); }
         });
     }
-    RED.nodes.registerType("natrail",NatRailNode, {
-        credentials: { apikey: {type:"text"} }
-    });
+    RED.nodes.registerType("natrail",NatRailNode);
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     ],
     "node-red": {
         "nodes": {
-            "natrail": "natRail.js"
+            "natrail": "natRail.js",
+            "natRail-config": "natRail-config.js"
         }
     },
     "author": {


### PR DESCRIPTION
This adds a new configuration node to hold the API key for the web service, allowing multiple natrail nodes to be used without copying the API key around.

There's also a minor fix for the name field on the natrail node not showing a label.